### PR TITLE
Publish documentation website to gh-pages

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -1,0 +1,43 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+          cache-dependency-path: ./website/yarn.lock
+
+      - name: Install dependencies
+        run: cd website && yarn install --frozen-lockfile
+      - name: Build website
+        run: cd website && yarn build
+
+      # Popular action to deploy to GitHub Pages:
+      # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Build output to publish to the `gh-pages` branch:
+          publish_dir: ./website/build
+          # The following lines assign commit authorship to the official
+          # GH-Actions bot for deploys to `gh-pages` branch:
+          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+          # The GH actions bot is used by default if you didn't specify the two fields.
+          # You can swap them out with your own user credentials.
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -10,18 +10,26 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
 const {customFields} = require('./constants');
 
+const { organizationName, baseUrl } =
+  "GITHUB_REPOSITORY" in process.env
+    ? (() => {
+        const parts = process.env.GITHUB_REPOSITORY.split("/");
+        return { organizationName: parts[0], baseUrl: `/${parts[1]}/` };
+      })()
+    : { organizationName: "facebook", baseUrl: "/" };
+
 // With JSDoc @type annotations, IDEs can provide config autocompletion
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 (module.exports = {
   title: 'Scrut',
   tagline: 'A CLI Testing Framework',
   url: 'https://internalfb.com',
-  baseUrl: '/',
+  baseUrl,
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
   trailingSlash: true,
   favicon: 'img/favicon.ico',
-  organizationName: 'facebook',
+  organizationName,
   projectName: 'scrut', // TODO
   customFields,
 


### PR DESCRIPTION
This CL adds a Github Action to publish that publishes the [Docusaurus](https://docusaurus.io/) website that contains Scrut's documentation to the `gh-pages` branch.

Here the Github Page of my cloned repository that shows how the published website will look like: https://ukautz.github.io/scrut-tmp1/

The publishing is triggered on changes in the `main` branch and can be dispatched manually.