### PR TITLE
readme: link the tutorial doc in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ $ acme --version > /dev/null
 ```
 ````
 
+To start using Scrut, see the [Tutorial](https://facebookincubator.github.io/scrut/docs/tutorial/) page for a walkthrough of Scrut use from start to end.
+
 ## Contribute
 
 - [Contributing](CONTRIBUTING.md)


### PR DESCRIPTION
The tutorial is pretty good but not linked in the README. Adding it to README will enhance discoverability.