### PR TITLE
add a fail-fast flag

### DIFF
--- a/selftest/complex/inline-configuration/test-testcase-fail-fast.md
+++ b/selftest/complex/inline-configuration/test-testcase-fail-fast.md
@@ -1,0 +1,47 @@
+# Validate per-testcase fail_fast configuration
+
+Tests in this file validate that the `fail_fast` option stops execution of the entire test document when a test case fails.
+
+```scrut
+$ alias scrut_test='$SCRUT_BIN test --match-markdown="*.mdtest"'
+```
+
+## fail_fast stops on first failure
+
+```scrut
+$ scrut_test "$TESTDIR"/test-testcase-fail-fast.mdtest 2>&1
+// =============================================================================
+// @ *test-testcase-fail-fast.mdtest:* (glob)
+// -----------------------------------------------------------------------------
+// # Second test fails with fail_fast
+// -----------------------------------------------------------------------------
+// $ echo "Test 2"
+// =============================================================================
+
+1     | - Wrong output
+   1  | + Test 2
+
+
+Result: 1 document(s) with 3 testcase(s): 1 succeeded, 1 failed and 1 skipped
+[50]
+```
+
+## without fail_fast all tests run
+
+```scrut
+$ scrut_test "$TESTDIR"/test-testcase-no-fail-fast.mdtest 2>&1
+// =============================================================================
+// @ *test-testcase-no-fail-fast.mdtest:* (glob)
+// -----------------------------------------------------------------------------
+// # Second test fails without fail_fast
+// -----------------------------------------------------------------------------
+// $ echo "Test 2"
+// =============================================================================
+
+1     | - Wrong output
+   1  | + Test 2
+
+
+Result: 1 document(s) with 3 testcase(s): 2 succeeded, 1 failed and 0 skipped
+[50]
+```

--- a/selftest/complex/inline-configuration/test-testcase-fail-fast.mdtest
+++ b/selftest/complex/inline-configuration/test-testcase-fail-fast.mdtest
@@ -1,0 +1,24 @@
+# This test validates fail_fast stops execution on first failure
+
+This file has 3 tests: first passes, second fails with fail_fast enabled, third should be skipped.
+
+## First test passes
+
+```scrut
+$ echo "Test 1"
+Test 1
+```
+
+## Second test fails with fail_fast
+
+```scrut {fail_fast: true}
+$ echo "Test 2"
+Wrong output
+```
+
+## Third test should be skipped
+
+```scrut
+$ echo "Test 3"
+Test 3
+```

--- a/selftest/complex/inline-configuration/test-testcase-no-fail-fast.mdtest
+++ b/selftest/complex/inline-configuration/test-testcase-no-fail-fast.mdtest
@@ -1,0 +1,24 @@
+# This test validates normal behavior without fail_fast
+
+This file has 3 tests: first passes, second fails WITHOUT fail_fast, third should still run.
+
+## First test passes
+
+```scrut
+$ echo "Test 1"
+Test 1
+```
+
+## Second test fails without fail_fast
+
+```scrut
+$ echo "Test 2"
+Wrong output
+```
+
+## Third test should still run
+
+```scrut
+$ echo "Test 3"
+Test 3
+```

--- a/src/bin/commands/test.rs
+++ b/src/bin/commands/test.rs
@@ -294,51 +294,24 @@ impl Args {
 
                     // ... because test timed out
                     ExecutionError::Timeout(timeout, outputs) => {
-                        // append outcomes for each testcase that was executed (i.e. all testcase
-                        // until and including the one that timed out)
-                        outcomes.extend(outputs.iter().zip(testcases.iter()).map(
-                            |(output, testcase)| {
-                                let result = if matches!(output.exit_code, ExitStatus::Timeout(_)) {
-                                    count_failed += 1;
+                        handle_early_termination(
+                            &outputs,
+                            &testcases,
+                            &mut outcomes,
+                            test.path.display().to_string(),
+                            escaping.clone(),
+                            test.parser_type,
+                            &mut count_success,
+                            &mut count_failed,
+                            &mut count_skipped,
+                            |output, testcase| {
+                                if matches!(output.exit_code, ExitStatus::Timeout(_)) {
                                     Err(TestCaseError::Timeout)
                                 } else {
-                                    let result = testcase.validate(output);
-                                    if result.is_err() {
-                                        count_failed += 1;
-                                        result
-                                    } else {
-                                        count_success += 1;
-                                        Ok(())
-                                    }
-                                };
-                                Outcome {
-                                    location: Some(test.path.display().to_string()),
-                                    testcase: (*testcase).clone(),
-                                    output: output.clone(),
-                                    escaping: escaping.clone(),
-                                    format: test.parser_type,
-                                    result,
+                                    testcase.validate(output)
                                 }
                             },
-                        ));
-
-                        // append outcomes for each testcase that was not executed (i.e. all
-                        // testcases after the one that timed out)
-                        let missing = testcases.len() - outputs.len();
-                        if missing > 0 {
-                            outcomes.extend(testcases.iter().skip(outputs.len()).map(|testcase| {
-                                Outcome {
-                                    location: Some(test.path.display().to_string()),
-                                    testcase: (*testcase).clone(),
-                                    output: ("", "", None).into(),
-                                    escaping: escaping.clone(),
-                                    format: test.parser_type,
-                                    result: Err(TestCaseError::Skipped),
-                                }
-                            }));
-
-                            count_skipped += missing;
-                        }
+                        );
 
                         let (location, timeout) = match timeout {
                             ExecutionTimeout::Index(idx) => (
@@ -357,6 +330,29 @@ impl Args {
                                 |t| format_duration(t).to_string()
                             ),
                             location,
+                        ));
+                        continue;
+                    }
+
+                    // ... because test failed with fail_fast enabled
+                    ExecutionError::Failed(idx, outputs) => {
+                        handle_early_termination(
+                            &outputs,
+                            &testcases,
+                            &mut outcomes,
+                            test.path.display().to_string(),
+                            escaping.clone(),
+                            test.parser_type,
+                            &mut count_success,
+                            &mut count_failed,
+                            &mut count_skipped,
+                            |output, testcase| testcase.validate(output),
+                        );
+
+                        pw.println(format!(
+                            "⚡ {}: stopped at testcase #{} due to fail_fast",
+                            style(test.path.to_string_lossy()).red(),
+                            idx + 1,
                         ));
                         continue;
                     }
@@ -477,6 +473,65 @@ impl Args {
     /// values set which are provided by the user.
     fn to_testcase_config(&self) -> TestCaseConfig {
         self.global.to_testcase_config()
+    }
+}
+
+/// Helper function to handle early termination cases (timeout, fail_fast).
+/// Validates outputs that were collected, marks remaining tests as skipped.
+fn handle_early_termination<'a, F>(
+    outputs: &[scrut::output::Output],
+    testcases: &[&TestCase],
+    outcomes: &mut Vec<Outcome>,
+    location: String,
+    escaping: scrut::escaping::Escaper,
+    format: ParserType,
+    count_success: &mut usize,
+    count_failed: &mut usize,
+    count_skipped: &mut usize,
+    mut validate_output: F,
+) where
+    F: FnMut(&scrut::output::Output, &TestCase) -> Result<(), TestCaseError>,
+{
+    // append outcomes for each testcase that was executed
+    outcomes.extend(
+        outputs
+            .iter()
+            .zip(testcases.iter())
+            .map(|(output, testcase)| {
+                let result = validate_output(output, testcase);
+                if result.is_err() {
+                    *count_failed += 1;
+                } else {
+                    *count_success += 1;
+                }
+                Outcome {
+                    location: Some(location.clone()),
+                    testcase: (*testcase).clone(),
+                    output: output.clone(),
+                    escaping: escaping.clone(),
+                    format,
+                    result,
+                }
+            }),
+    );
+
+    // append outcomes for testcases not executed
+    let missing = testcases.len() - outputs.len();
+    if missing > 0 {
+        outcomes.extend(
+            testcases
+                .iter()
+                .skip(outputs.len())
+                .map(|testcase| Outcome {
+                    location: Some(location.clone()),
+                    testcase: (*testcase).clone(),
+                    output: ("", "", None).into(),
+                    escaping: escaping.clone(),
+                    format,
+                    result: Err(TestCaseError::Skipped),
+                }),
+        );
+        *count_skipped += missing;
     }
 }
 

--- a/src/executors/error.rs
+++ b/src/executors/error.rs
@@ -57,6 +57,11 @@ pub enum ExecutionError {
     /// out or if all are (see [`ExecutionTimeout`])
     Timeout(ExecutionTimeout, Vec<Output>),
 
+    /// Returned if a [`crate::testcase::TestCase`] failed validation and had
+    /// fail_fast set to true, causing immediate termination of the test document.
+    /// Contains the index of the failed test and all outputs collected so far.
+    Failed(usize, Vec<Output>),
+
     /// Returned if a specific [`crate::testcase::TestCase`] execution is
     /// intentionally skipped by the user.
     /// This is not a final error.
@@ -128,6 +133,9 @@ impl Display for ExecutionError {
                 ),
                 ExecutionTimeout::Total => write!(f, "timeout in executing"),
             },
+            ExecutionError::Failed(idx, _output) => {
+                write!(f, "test {} failed with fail_fast enabled", idx + 1)
+            }
             ExecutionError::Skipped(idx) => write!(f, "skipped test {}", idx + 1),
         }
     }

--- a/src/executors/stateful_executor.rs
+++ b/src/executors/stateful_executor.rs
@@ -154,6 +154,13 @@ impl Executor for StatefulExecutor {
 
                     // .. otherwise keep collecting output
                     outputs.push(output);
+
+                    // check if fail_fast is enabled and validation fails
+                    if testcase.config.get_fail_fast() {
+                        if testcase.validate(outputs.last().unwrap()).is_err() {
+                            return Err(ExecutionError::Failed(index, outputs));
+                        }
+                    }
                 }
 
                 // running into a timeout ends all execution ..

--- a/website/docs/reference/fundamentals/inline-configuration.md
+++ b/website/docs/reference/fundamentals/inline-configuration.md
@@ -200,6 +200,24 @@ Kill signals are only supported on Linux and MacOS. They are ignored (but valida
 
 :::
 
+### `fail_fast`
+
+- Type: **boolean**
+- Command Line Parameter: **n/a**
+- Default: **`false`**
+
+If set to `true`, stops execution of the entire test document immediately if this test case fails for any reason (exit status, snapshot validation, etc.). All remaining test cases in the document will be marked as skipped. This is useful when a critical test fails and subsequent tests are not meaningful or would fail anyway.
+
+**Example:**
+
+````markdown showLineNumbers
+```scrut {fail_fast: true}
+$ critical-setup-command
+```
+````
+
+In this example, if `critical-setup-command` fails, all subsequent tests in the document are skipped.
+
 ### `environment`
 
 - Type: **object**


### PR DESCRIPTION
This resolves #41. Full disclosure: this change was coded by an AI agent. Original prompt:

> Please build a feature for fast failures. It should be a test case configuration option (similar to "detached") named  "fail_fast". When set, if the test case fails for any reason (exit status, snapshot, etc), the entire test document immediately stops.

I reviewed the code and tests, and tested the result in my actual scrut deployment.