### PR TITLE
update regex crate: 1.11.1 -> 1.12.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ humantime = "2.1"
 indicatif = { version = "0.18.3", features = ["futures", "improved_unicode", "rayon", "tokio"] }
 lazy_static = "1.5"
 rand = { version = "0.8", features = ["small_rng"] }
-regex = "1.11.1"
+regex = "1.12.2"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 serde_yaml = "0.9.25"


### PR DESCRIPTION
Summary:
Primarily updating for https://docs.rs/regex/latest/regex/struct.Captures.html#method.get_match to avoid explicit `unwrap()` in production code

https://github.com/rust-lang/regex/blob/master/CHANGELOG.md

Differential Revision: D87950658


