### PR TITLE
Update version in cargo.toml to match current version (0.4.2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "scrut"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.85"
 description = "A simple and powerful test framework for CLI applications"


### PR DESCRIPTION
`scrut --version` currently returns `0.4.1`, even though it's ostensibly `0.4.2`. I took a quick look through the codebase and `cargo.toml` seemed like the place to change it, though I couldn't tell if perhaps you're injecting a version environment variable at some point elsewhere.